### PR TITLE
fixed cloud config not in the container

### DIFF
--- a/quiz.Dockerfile
+++ b/quiz.Dockerfile
@@ -3,5 +3,5 @@ EXPOSE 8082
 CMD ["java", "-Dspring.profiles.active=cloud", "-jar", "rest-service-0.0.1-SNAPSHOT.jar"]
 
 COPY target/rest-service-0.0.1-SNAPSHOT.jar .
-COPY src/main/resources/application.properties /
-RUN mv application.properties config.properties
+COPY src/main/resources/application-cloud.properties /
+RUN mv application-cloud.properties config.properties


### PR DESCRIPTION
I somehow forgot to push this change before? Everything is working, but only on my side I suppose, but this should allow others to build containers.